### PR TITLE
Properly use kwargs for prefect's result target templating

### DIFF
--- a/xpersist/prefect/result.py
+++ b/xpersist/prefect/result.py
@@ -26,7 +26,7 @@ class XpersistResult(Result):
         The keyword arguments to pass to the serializer's `dump` method.
     serializer_load_kwargs : dict
         The keyword arguments to pass to the serializer's `load` method.
-    kwargs: dict
+    kwargs : dict
         Any additional keyword arguments to pass to the `Result` class.
     """
 
@@ -59,7 +59,7 @@ class XpersistResult(Result):
 
         Returns
         -------
-        result: Result
+        result : Result
             a new result instance with the data represented by the location
         """
         new = self.copy()
@@ -86,7 +86,7 @@ class XpersistResult(Result):
 
         Returns
         -------
-        result: Result
+        result : Result
             A new `Result` instance with the location of the written result.
 
         """

--- a/xpersist/prefect/result.py
+++ b/xpersist/prefect/result.py
@@ -15,6 +15,19 @@ from ..cache import CacheStore
 class XpersistResult(Result):
     """
     A result class that is used to store the results of a task in a xpersist Metadata store.
+
+    Parameters
+    ----------
+    cache_store : :py:class:`xpersist.cache.CacheStore`
+        The cache store to use for storing the result.
+    serializer : str
+        The serializer to use for storing the result.
+    serializer_dump_kwargs : dict
+        The keyword arguments to pass to the serializer's `dump` method.
+    serializer_load_kwargs : dict
+        The keyword arguments to pass to the serializer's `load` method.
+    kwargs: dict
+        Any additional keyword arguments to pass to the `Result` class.
     """
 
     cache_store: CacheStore
@@ -37,17 +50,17 @@ class XpersistResult(Result):
 
     def read(self, location: str) -> Result:
         """
-        Reads the result from the metadata store.
+        Reads a result from the cache store and returns the corresponding `Result` instance.
 
         Parameters
         ----------
         location : str
-            The location of the result to read.
+            the location to read from
 
         Returns
         -------
-        Result
-            The result at the given location.
+        result: Result
+            a new result instance with the data represented by the location
         """
         new = self.copy()
         new.location = location
@@ -59,14 +72,23 @@ class XpersistResult(Result):
 
     def write(self, value_: typing.Any, **kwargs: typing.Any) -> Result:
         """
-        Writes the result to the metadata store.
+        Writes the result to a location in the cache store and returns a new `Result`
+        object with the result's location.
 
         Parameters
         ----------
         value_ : typing.Any
-            The value to write to the metadata store.
-        kwargs : typing.Any
-            Additional keyword arguments
+            the value to write; will then be stored as the `value` attribute
+            of the returned `Result` instance
+        kwargs : dict
+            if provided, will be used to format the location template
+            to determine the location to write to
+
+        Returns
+        -------
+        result: Result
+            A new `Result` instance with the location of the written result.
+
         """
 
         new = self.format(**kwargs)
@@ -90,11 +112,17 @@ class XpersistResult(Result):
         Parameters
         ----------
         location : str
-            The location of the result to check.
-        kwargs : typing.Any
-            Additional keyword arguments.
+            Location of the result in the specific result target.
+            Will check whether the provided location exists
+        kwargs : dict
+            string format arguments for `location`
+
+        Returns
+        -------
+        _ : bool
+            whether or not the target result exists
         """
-        return location in self.cache_store
+        return location.format(**kwargs) in self.cache_store
 
 
 # Fixes https://github.com/samuelcolvin/pydantic/issues/704

--- a/xpersist/prefect/result.py
+++ b/xpersist/prefect/result.py
@@ -69,7 +69,7 @@ class xpersistResult(Result):
             Additional keyword arguments
         """
 
-        new = self.format(**{})
+        new = self.format(**kwargs)
         new.value = value_
         assert new.location is not None
 


### PR DESCRIPTION
## Change Summary

<!-- Please give a short summary of the changes. -->

Migrating this PR from esds-funnel.

While using funnel for caching, I ran into an unexpected error when trying to apply formatting for target names based on [prefect parameters](https://docs.prefect.io/core/concepts/templating.html#using-flow-parameters).


<details>
traceback:
```└── 16:41:35 | ERROR   | Unexpected error: KeyError('gcm')
Traceback (most recent call last):
  File "/Users/nrhagen/opt/anaconda3/envs/install/envs/cmip6-jupyter/lib/python3.9/site-packages/prefect/engine/runner.py", line 48, in inner
    new_state = method(self, state, *args, **kwargs)
  File "/Users/nrhagen/opt/anaconda3/envs/install/envs/cmip6-jupyter/lib/python3.9/site-packages/prefect/engine/task_runner.py", line 926, in get_task_run_state
    result = self.result.write(value, **formatting_kwargs)
  File "/Users/nrhagen/opt/anaconda3/envs/install/envs/cmip6-jupyter/lib/python3.9/site-packages/funnel/prefect/result.py", line 72, in write
    new = self.format(**{})
  File "/Users/nrhagen/opt/anaconda3/envs/install/envs/cmip6-jupyter/lib/python3.9/site-packages/prefect/engine/result/base.py", line 133, in format
    new.location = new.location.format(**kwargs)
KeyError: 'gcm'
└── 16:41:35 | INFO    | Task 'test_kwargs': Finished task run for task with final state: 'Failed'
└── 16:41:35 | INFO    | Flow run FAILED: some reference tasks failed.
Flow run failed!
</details>


By editing line 72 of funnel/prefect/result.py from `new = self.format(**{})` to `new = self.format(**kwargs)`, the targeting templating seemed to succeed.

Credit goes to @tcchiao for finding a fix. 

## Related issue number

https://github.com/NCAR/esds-funnel/pull/59

## Checklist

- [ ] Unit tests for the changes exist
- [x] Tests pass on CI
- [ ] Documentation reflects the changes where applicable


